### PR TITLE
Add a typhoon_livox independent frame

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -77,4 +77,6 @@ px4_add_romfs_files(
 	2507_cloudship
 	6011_typhoon_h480
 	6011_typhoon_h480.post
+	6012_typhoon_h480_livox
+	6012_typhoon_h480_livox.post
 )

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -171,6 +171,7 @@ set(models
 	techpod
 	tiltrotor
 	typhoon_h480
+	typhoon_h480_livox
 	uuv_bluerov2_heavy
 	uuv_hippocampus
 )


### PR DESCRIPTION
This PR:
Closes https://github.com/Airtonomy/flight-gazebo-sim/issues/21


## Describe your solution
PR adds an independent typhoon airframe carrying the livox lidar stack.